### PR TITLE
fix rendering broken links in root event message in nostr clients

### DIFF
--- a/src/reply.tsx
+++ b/src/reply.tsx
@@ -144,7 +144,7 @@ export const ReplyEditor = (props: { replyTo?: string; onDone?: Function; }) => 
           created_at: Math.round(Date.now() / 1000),
           kind: 1,
           tags: [['r', url]],
-          content: `Comments on ${url}↴`
+          content: `Comments on ${url} ↴`
         };
 
         const rootEvent: Event<1> = {


### PR DESCRIPTION
Thank you for creating zapthreads!

This change fixes the rendering of broken links in root event messages in nostr clients, due to arrow signal getting appended to url

![Screenshot 2024-03-28 at 14 12 28](https://github.com/fr4nzap/zapthreads/assets/685599/21bab6b4-cc12-41f6-aa05-a6c5ca6b19b6)
